### PR TITLE
Add continuum support for multiple sockets

### DIFF
--- a/continuum.tmux
+++ b/continuum.tmux
@@ -63,6 +63,7 @@ update_tmux_option() {
 	set_tmux_option "$option" "$new_option_value"
 }
 
+
 main() {
 	if supported_tmux_version_ok; then
 		handle_tmux_automatic_start
@@ -70,7 +71,7 @@ main() {
 		# Advanced edge case handling: start auto-saving only if this is the
 		# only tmux server. We don't want saved files from more environments to
 		# overwrite each other.
-		if ! another_tmux_server_running; then
+		if ! another_tmux_server_running || multiple_sockets_enabled; then
 			# give user a chance to restore previously saved session
 			delay_saving_environment_on_first_plugin_load
 			add_resurrect_save_interpolation

--- a/scripts/continuum_restore.sh
+++ b/scripts/continuum_restore.sh
@@ -22,7 +22,7 @@ fetch_and_run_tmux_resurrect_restore_script() {
 main() {
 	# Advanced edge case handling: auto restore only if this is the only tmux
 	# server. If another tmux server exists, it is assumed auto-restore is not wanted.
-	if auto_restore_enabled && ! another_tmux_server_running_on_startup; then
+	if auto_restore_enabled && ( ! another_tmux_server_running_on_startup || multiple_sockets_enabled); then
 		fetch_and_run_tmux_resurrect_restore_script
 	fi
 }

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -47,3 +47,8 @@ another_tmux_server_running_on_startup() {
 	# there are 2 tmux processes (current tmux server + 1) on tmux startup
 	[ "$(number_tmux_processes_except_current_server)" -gt 1 ]
 }
+
+multiple_sockets_enabled() {
+  local multiple_sockets_value="$(get_tmux_option "$multiple_sockets_option" "$multiple_sockets_default")"
+  [ "$multiple_sockets_value" == "on" ]
+}

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -7,6 +7,10 @@ resurrect_restore_path_option="@resurrect-restore-script-path"
 auto_save_interval_option="@continuum-save-interval"
 auto_save_interval_default="15"
 
+# enable plugin even if multiple sockets exist
+multiple_sockets_option="@continuum-multiple-sockets"
+multiple_sockets_default="off"
+
 # time when the tmux environment was last saved (unix timestamp)
 last_auto_save_option="@continuum-save-last-timestamp"
 


### PR DESCRIPTION
## Summary
Add new option variable `@continuum-multiple-sockets` to be able to override `multiple clients`.
To enable set it to `on`:
```
set -g @continuum-multiple-sockets 'on'
```
This way, continuum will run no matter how many clients exist.

This is useful in case you try to separate `tmux` sessions by `socket`:
```
tmux -L $socket_name
```
for example:
```
tmux -L work
tmux -L personal
```
Now, each socket is isolated and has its own sessions.
> When running only `tmux`, socket is named `default`.

## Important
If you use
```
set -g @continuum-restore 'on'
```
to automatically restore sessions on `tmux` start, there will always  be one session that is created after restore.
This is known issue for `tmux-continuum`. To bypass this and have clean restore, start tmux like:
```
tmux -L $socket start-server
```
This will start `tmux` in background without any sessions. `tmux-continuum` will restore saved sessions.
Then you can just attach with:
```
tmux -L $socket at
```

It can be automated something like:
```
tmux -L $socket start-server
until tmux -L $socket list-sessions &>/dev/null; do
  sleep 1
done
tmux -L $socket at
```
> This creates new `tmux` client. `tmux-continuum` will start restore.
> In the meantime, we will be checking for sessions with `list-sessions`.
> As soon as there are some sesssion, we will attach.

This is useful if you start `tmux` in background and then start using it some time later.